### PR TITLE
Enable curl verbose mode in aws

### DIFF
--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -42,6 +42,7 @@ vcpkg_cmake_configure(
         "-DBUILD_ONLY=${BUILD_ONLY}"
 		"-DFORCE_CURL=ON"		# TRICE - use curl on all platforms 
 		"-DCPP_STANDARD=17"		# TRICE - use c++17 for string_view 
+		"-DCURLOPT_VERBOSE=1"		# TRICE - log curl internals		
         "-DBUILD_DEPS=OFF"
         "-DBUILD_SHARED_LIBS=OFF"
         "-DCMAKE_INSTALL_RPATH=${rpath}"


### PR DESCRIPTION
Set the CURLOPT_VERBOSE option in aws-sdk-cpp to allow for curl timeout reasons to be logged