### PR TITLE
DEV-2556 Ignore deprecated sprintf usage in aws-crt-cpp

### DIFF
--- a/ports/aws-crt-cpp/TRICE.macos-sprintf-deprecation.patch
+++ b/ports/aws-crt-cpp/TRICE.macos-sprintf-deprecation.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 733b18a..61e2bbe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -176,6 +176,7 @@ endif()
+ 
+ include(AwsCFlags)
+ include(AwsSharedLibSetup)
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+ 
+ file(GLOB AWS_CRT_HEADERS
+     "include/aws/crt/*.h"

--- a/ports/aws-crt-cpp/portfile.cmake
+++ b/ports/aws-crt-cpp/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     PATCHES
         fix-cmake-target-path.patch
         fix-ios-build.patch
+        TRICE.macos-sprintf-deprecation.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)


### PR DESCRIPTION
[DEV-2556](https://trice.atlassian.net/browse/DEV-2556) On macOS with SDK 13.0, the `aws-crt-cpp` package does not compile anymore
The upstream package has newer versions with a fix. However, it seems like we would need to update several underlying `aws-*` packages as well.

Take the short-term solution of adding a compiler flag instead.

