### PR TITLE
DEV-3283 Explicitly disable OpenJPEG option for dcmtk.

### DIFF
--- a/ports/dcmtk/portfile.cmake
+++ b/ports/dcmtk/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_cmake_configure(
         -DCMAKE_CXX_STANDARD=17
 		-DDCMTK_DEFAULT_DICT=builtin	# TRICE enable builtin dictionary
         -DDCMTK_WIDE_CHAR_FILE_IO_FUNCTIONS=ON
+        -DDCMTK_WITH_OPENJPEG=OFF
         -DDCMTK_WIDE_CHAR_MAIN_FUNCTION=ON
         -DDCMTK_ENABLE_STL=ON
         -DCMAKE_DEBUG_POSTFIX=d


### PR DESCRIPTION
[DEV-3283](https://trice.atlassian.net/browse/DEV-3283) With Homebrew, OpenJPEG can be "opportunistically" picked up by the vcpkg portfile for dcmtk, which breaks the build

[DEV-3283]: https://trice.atlassian.net/browse/DEV-3283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ