### PR TITLE
DEV-4070 Update sentry-native port to include static library pthread fix

### DIFF
--- a/ports/sentry-native/fix-config-cmake.patch
+++ b/ports/sentry-native/fix-config-cmake.patch
@@ -2,42 +2,20 @@ diff --git a/sentry-config.cmake.in b/sentry-config.cmake.in
 index 70ce7d3..796d428 100644
 --- a/sentry-config.cmake.in
 +++ b/sentry-config.cmake.in
-@@ -1,5 +1,7 @@
- @PACKAGE_INIT@
+@@ -9,7 +9,7 @@ set(SENTRY_LINK_PTHREAD @SENTRY_LINK_PTHREAD@)
 
-+include(CMakeFindDependencyMacro)
-+
- set(SENTRY_BACKEND @SENTRY_BACKEND@)
- set(SENTRY_TRANSPORT @SENTRY_TRANSPORT@)
- set(SENTRY_BUILD_SHARED_LIBS @SENTRY_BUILD_SHARED_LIBS@)
-@@ -8,14 +10,14 @@ set(SENTRY_LINK_PTHREAD @SENTRY_LINK_PTHREAD@)
- if(SENTRY_BACKEND STREQUAL "crashpad" AND NOT SENTRY_BUILD_SHARED_LIBS)
+ if(SENTRY_BACKEND STREQUAL "crashpad")
  	include("${CMAKE_CURRENT_LIST_DIR}/sentry_crashpad-targets.cmake")
- 	if(NOT MSVC AND NOT SENTRY_BUILD_SHARED_LIBS)
--		find_package(ZLIB REQUIRED)
-+		find_dependency(ZLIB)
+-	if(NOT MSVC AND NOT SENTRY_BUILD_SHARED_LIBS)
++	if(NOT SENTRY_BUILD_SHARED_LIBS)
+ 		find_dependency(ZLIB REQUIRED)
  	endif()
  endif()
-
- if(SENTRY_BACKEND STREQUAL "breakpad" AND NOT SENTRY_BUILD_SHARED_LIBS)
- 	set(SENTRY_BREAKPAD_SYSTEM @SENTRY_BREAKPAD_SYSTEM@)
- 	if(SENTRY_BREAKPAD_SYSTEM)
--		find_package(PkgConfig REQUIRED)
-+		find_dependency(PkgConfig)
- 		pkg_check_modules(BREAKPAD REQUIRED IMPORTED_TARGET breakpad-client)
- 	endif()
- endif()
-@@ -23,11 +25,9 @@ endif()
+@@ -23,7 +23,5 @@ endif()
  include("${CMAKE_CURRENT_LIST_DIR}/sentry-targets.cmake")
 
  if(SENTRY_TRANSPORT STREQUAL "curl" AND (NOT @BUILD_SHARED_LIBS@ OR NOT SENTRY_BUILD_SHARED_LIBS))
--	find_package(CURL REQUIRED)
+ 	find_dependency(CURL REQUIRED)
 -	set_property(TARGET sentry::sentry APPEND
 -		PROPERTY INTERFACE_LINK_LIBRARIES ${CURL_LIBRARIES})
-+	find_dependency(CURL)
- endif()
-
- if(SENTRY_LINK_PTHREAD AND NOT SENTRY_BUILD_SHARED_LIBS)
--	find_package(Threads REQUIRED)
-+	find_dependency(Threads)
  endif()

--- a/ports/sentry-native/fix-find-dependency.patch
+++ b/ports/sentry-native/fix-find-dependency.patch
@@ -1,0 +1,33 @@
+diff --git a/sentry-config.cmake.in b/sentry-config.cmake.in
+index 1e3871f..e38b0c7 100644
+--- a/sentry-config.cmake.in
++++ b/sentry-config.cmake.in
+@@ -9,14 +9,14 @@ set(SENTRY_LINK_PTHREAD @SENTRY_LINK_PTHREAD@)
+ if(SENTRY_BACKEND STREQUAL "crashpad")
+ 	include("${CMAKE_CURRENT_LIST_DIR}/sentry_crashpad-targets.cmake")
+ 	if(NOT SENTRY_BUILD_SHARED_LIBS)
+-		find_dependency(ZLIB REQUIRED)
++		find_dependency(ZLIB)
+ 	endif()
+ endif()
+
+ if(SENTRY_BACKEND STREQUAL "breakpad" AND NOT SENTRY_BUILD_SHARED_LIBS)
+ 	set(SENTRY_BREAKPAD_SYSTEM @SENTRY_BREAKPAD_SYSTEM@)
+ 	if(SENTRY_BREAKPAD_SYSTEM)
+-		find_dependency(PkgConfig REQUIRED)
++		find_dependency(PkgConfig)
+ 		pkg_check_modules(BREAKPAD REQUIRED IMPORTED_TARGET breakpad-client)
+ 	endif()
+ endif()
+@@ -24,9 +24,9 @@ endif()
+ include("${CMAKE_CURRENT_LIST_DIR}/sentry-targets.cmake")
+
+ if(SENTRY_TRANSPORT STREQUAL "curl" AND (NOT @BUILD_SHARED_LIBS@ OR NOT SENTRY_BUILD_SHARED_LIBS))
+-	find_dependency(CURL REQUIRED)
++	find_dependency(CURL)
+ endif()
+
+ if(SENTRY_LINK_PTHREAD AND NOT SENTRY_BUILD_SHARED_LIBS)
+-	find_dependency(Threads REQUIRED)
++	find_dependency(Threads)
+ endif()

--- a/ports/sentry-native/fix-usage-runtime.patch
+++ b/ports/sentry-native/fix-usage-runtime.patch
@@ -1,0 +1,13 @@
+diff --git a/external/crashpad/handler/CMakeLists.txt b/external/crashpad/handler/CMakeLists.txt
+index be0e544..b0d44af 100644
+--- a/external/crashpad/handler/CMakeLists.txt
++++ b/external/crashpad/handler/CMakeLists.txt
+@@ -89,7 +89,7 @@ if(NOT IOS)
+         main.cc
+     )
+
+-    if(LINUX)
++    if(LINUX AND BUILD_SHARED_LIBS)
+         target_sources(crashpad_handler PRIVATE
+             ../client/pthread_create_linux.cc
+         )

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/${VERSION}/sentry-native.zip"
     FILENAME "sentry-native-${VERSION}.zip"
-    SHA512 26976e6f349e5a94a5ce83bc30cd9306d402ca4ed84382ba24a267c116a8d6ba2dadd0b300e5924c69bc5dd39531e3f6e39820a0b40ccf2b673937ad58de3860
+    SHA512 92bdbc6edeeb687b30e654e011a1b45abf3ff0b8e2fe22025889550bcadfde50a6895a9539136c02a298013f6890faf41f30f9e2b0f8e2af8d0661edf0083fb3
 )
 
 vcpkg_extract_source_archive(
@@ -11,6 +11,8 @@ vcpkg_extract_source_archive(
     PATCHES
         fix-config-cmake.patch
         fix-crashpad-wer.patch
+        fix-usage-runtime.patch
+        fix-find-dependency.patch
 )
 file(REMOVE_RECURSE "${SOURCE_PATH}/external/crashpad/third_party/zlib/zlib")
 

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-native",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8025,7 +8025,7 @@
       "port-version": 0
     },
     "sentry-native": {
-      "baseline": "0.7.4",
+      "baseline": "0.7.6",
       "port-version": 0
     },
     "septag-dmon": {

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,21 @@
 {
   "versions": [
     {
+      "git-tree": "f1f62e4b208a45ed18abea06b7221fb3c16291c9",
+      "version": "0.7.6",
+      "port-version": 0
+    },
+    {
+      "git-tree": "b7ec5e8b622f2026bb79fd536c893742ff48afa0",
+      "version": "0.7.5",
+      "port-version": 1
+    },
+    {
+      "git-tree": "83ff49b00c2fd8159701cc2f8489a10a6959227c",
+      "version": "0.7.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "1c5ae9657d5c7fdee6e70a240c6941ba6b5bbb72",
       "version": "0.7.4",
       "port-version": 0


### PR DESCRIPTION
[DEV-4070](https://trice.atlassian.net/browse/DEV-4070)

Jason had tweaked the `sentry-native` port due to an issue with crashpad and static library usage a while back, see https://github.com/getsentry/sentry-native/issues/596 and https://github.com/trice-imaging/edgeLink/pull/289.
I forgot to bring that patch forward when updating our `vcpkg` branch. As luck would have it, someone else [referenced Jason's original issue and ported the fix](https://github.com/microsoft/vcpkg/pull/39122) directly to upstream vcpkg.


##### Changes
- cherry-pick the latest `sentry-native` port changes from upstream vcpkg

[DEV-4070]: https://trice.atlassian.net/browse/DEV-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ